### PR TITLE
Fix name error and single webhook error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "silanthro/slack"
+name = "slack"
 version = "0.1.0"
 description = "A tool to send Slack messages."
 readme = "README.md"

--- a/slack.py
+++ b/slack.py
@@ -47,13 +47,19 @@ def send_message(content: str, channel: Optional[str] = None) -> str:
     """
 
     webhook = None
-    if channel is None:
-        if isinstance(WEBHOOKS, str):
-            webhook = WEBHOOKS
-        else:
+    if isinstance(WEBHOOKS, str):
+        webhook = WEBHOOKS
+        if not webhook:
+            raise ValueError("SLACK_WEBHOOKS is empty.")
+    elif channel is None:
+        try:
             webhook = list(WEBHOOKS.values())[0]
+        except IndexError:
+            raise ValueError("SLACK_WEBHOOKS is empty or has no values.")
     else:
-        webhook = WEBHOOKS[channel]
+        webhook = WEBHOOKS.get(channel)
+        if webhook is None:
+            raise ValueError(f"No webhook configured for channel '{channel}' in SLACK_WEBHOOKS.")
 
     body = {
         "blocks": [

--- a/slack.py
+++ b/slack.py
@@ -9,13 +9,20 @@ def _get_webhooks() -> dict:
     webhooks_str = os.environ.get("SLACK_WEBHOOKS")
     if not webhooks_str:
         raise ValueError("No webhooks provided via environment variable SLACK_WEBHOOKS")
-    if "{" in webhooks_str:
-        return json.loads(webhooks_str)
-    else:
-        return webhooks_str
+    return json.loads(webhooks_str)
 
 
 WEBHOOKS = _get_webhooks()
+
+
+def get_available_channels() -> list[str]:
+    """
+    Retrieve the list of available Slack channels
+
+    Returns:
+        A list of strings representing available Slack channels
+    """
+    return list(WEBHOOKS.keys())
 
 
 def send_message(content: str, channel: Optional[str] = None) -> str:

--- a/tools.toml
+++ b/tools.toml
@@ -3,5 +3,6 @@
 description = "A tool to send Slack messages."
 
 tools = [
+    "slack.get_available_channels",
     "slack.send_message",
 ]


### PR DESCRIPTION
1. The `/` in the name in `pyproject.toml` is causing an issue. Project names in `pyproject.toml` must follow PEP 508 identifier rules, which don’t accept /. Removing it stopped this error: `subprocess.CalledProcessError: Command '['.venv/bin/pip', 'install', '.']' returned non-zero exit status 1.`
2. When SLACK_WEBHOOKS is a string and a channel is given, webhook = WEBHOOKS[channel] gives an error because WEBHOOKS is a string. Also, Gemini will always ask for a channel if none is specified in the prompt. So, setting one webhook and providing a channel in the prompt will trigger `AttributeError: 'str' object has no attribute 'get'`
